### PR TITLE
fix error during build: No key, method or field with name 'DEFOLD_DEV…

### DIFF
--- a/html5/engine_template.html
+++ b/html5/engine_template.html
@@ -43,7 +43,6 @@
       }
     </style>
 
-    {{{DEFOLD_DEV_HEAD}}}
   </head>
   <body>
     <div id="app-container" class="canvas-app-container">
@@ -127,7 +126,7 @@
       };
     </script>
 
-    {{{DEFOLD_DEV_INLINE}}}
+    {{{DEFOLD_CUSTOM_CSS_INLINE}}}
     <script src="dmloader.js" embed></script>
 
     <script>


### PR DESCRIPTION
Fix for error during build: No key, method or field with name 'DEFOLD_DEV_HEAD'

based on bug and PR from FB Instant exporter project: https://forum.defold.com/t/facebook-instant-export-error-solved/63463/2